### PR TITLE
Switching to mach langpack-* for building locales

### DIFF
--- a/firefox/MozillaFirefox.spec
+++ b/firefox/MozillaFirefox.spec
@@ -287,7 +287,7 @@ if (( $(stat -Lc%s "%{SOURCE7}") < MINSIZE)); then
     exit 1
 fi
 
-%setup -q -n %{srcname}-%{orig_version} -b 7 -b 10
+%setup -q -n %{srcname}-%{orig_version} -b 7
 %else
 %setup -q -n %{srcname}-%{orig_version}
 %endif

--- a/firefox/MozillaFirefox.spec
+++ b/firefox/MozillaFirefox.spec
@@ -148,7 +148,6 @@ Source5:        source-stamp.txt
 Source7:        l10n-%{orig_version}%{orig_suffix}.tar.xz
 Source8:        firefox-mimeinfo.xml
 Source9:        firefox.js
-Source10:       compare-locales.tar.xz
 Source11:       firefox.1
 Source12:       mozilla-get-app-id
 Source13:       spellcheck.js
@@ -473,6 +472,31 @@ rm -f config/external/icu/data/icudt*l.dat
 xvfb-run --server-args="-screen 0 1920x1080x24" \
 %endif
 ./mach build -v
+
+# build additional locales
+%if %localize
+mkdir -p %{buildroot}%{progdir}/browser/extensions
+truncate -s 0 %{_tmppath}/translations.{common,other}
+sed -r '/^(ja-JP-mac|en-US|)$/d;s/ .*$//' $RPM_BUILD_DIR/%{source_prefix}/browser/locales/shipped-locales \
+    | xargs -n 1 -I {} /bin/sh -c '
+        locale=$1
+        ./mach build langpack-$locale
+        cp -rL ../obj/dist/xpi-stage/locale-$locale \
+            %{buildroot}%{progdir}/browser/extensions/langpack-$locale@firefox.mozilla.org
+        # remove prefs, profile defaults, and hyphenation from langpack
+        rm -rf %{buildroot}%{progdir}/browser/extensions/langpack-$locale@firefox.mozilla.org/defaults
+        rm -rf %{buildroot}%{progdir}/browser/extensions/langpack-$locale@firefox.mozilla.org/hyphenation
+        # check against the fixed common list and sort into the right filelist
+        _matched=0
+        for _match in ar ca cs da de el en-GB es-AR es-CL es-ES fi fr hu it ja ko nb-NO nl pl pt-BR pt-PT ru sv-SE zh-CN zh-TW; do
+            [ "$_match" = "$locale" ] && _matched=1
+        done
+        [ $_matched -eq 1 ] && _l10ntarget=common || _l10ntarget=other
+        echo %{progdir}/browser/extensions/langpack-$locale@firefox.mozilla.org \
+            >> %{_tmppath}/translations.$_l10ntarget
+' -- {}
+%endif
+
 %endif # only_print_mozconfig
 
 %install
@@ -501,35 +525,7 @@ mv %{buildroot}%{progdir}/%{srcname}-bin %{buildroot}%{progdir}/%{progname}
 install -m 644 %{SOURCE13} %{buildroot}%{progdir}/defaults/pref/
 # install browser prefs
 install -m 644 %{SOURCE9} %{buildroot}%{progdir}/browser/defaults/preferences/firefox.js
-# build additional locales
-%if %localize
-mkdir -p %{buildroot}%{progdir}/browser/extensions
-truncate -s 0 %{_tmppath}/translations.{common,other}
-sed -r '/^(ja-JP-mac|en-US|)$/d;s/ .*$//' $RPM_BUILD_DIR/%{srcname}-%{orig_version}/browser/locales/shipped-locales \
-    | xargs -n 1 -I {} /bin/sh -c '
-        locale=$1
-        pushd $RPM_BUILD_DIR/compare-locales
-        PYTHONPATH=lib \
-            scripts/compare-locales -m ../l10n-merged/$locale \
-            ../%{srcname}-%{orig_version}/browser/locales/l10n.ini ../l10n $locale
-        popd
-        LOCALE_MERGEDIR=$RPM_BUILD_DIR/l10n-merged/$locale \
-            make -C browser/locales langpack-$locale
-        cp -rL dist/xpi-stage/locale-$locale \
-            %{buildroot}%{progdir}/browser/extensions/langpack-$locale@firefox.mozilla.org
-        # remove prefs, profile defaults, and hyphenation from langpack
-        rm -rf %{buildroot}%{progdir}/browser/extensions/langpack-$locale@firefox.mozilla.org/defaults
-        rm -rf %{buildroot}%{progdir}/browser/extensions/langpack-$locale@firefox.mozilla.org/hyphenation
-        # check against the fixed common list and sort into the right filelist
-        _matched=0
-        for _match in ar ca cs da de el en-GB es-AR es-CL es-ES fi fr hu it ja ko nb-NO nl pl pt-BR pt-PT ru sv-SE zh-CN zh-TW; do
-            [ "$_match" = "$locale" ] && _matched=1
-        done
-        [ $_matched -eq 1 ] && _l10ntarget=common || _l10ntarget=other
-        echo %{progdir}/browser/extensions/langpack-$locale@firefox.mozilla.org \
-            >> %{_tmppath}/translations.$_l10ntarget
-' -- {}
-%endif
+
 # remove some executable permissions
 find %{buildroot}%{progdir} \
      -name "*.js" -o \


### PR DESCRIPTION
I built with this and the old way and compared the output of `rpm -ql MozillaFirefox-translations-common-68.1.0-0.x86_64.rpm`. They are identical.

Built-time was increased on my local machine by <10%, so it might very well be in the normal jitter.

If we use it like this, we can also remove the compare-locales-section in `create-tar.sh`