### PR TITLE
Stop the rust compiler to moan about "code that will be rejected by a future version of Rust" to make firefox115esr build

### DIFF
--- a/mozilla-rust-disable-future-incompat.patch
+++ b/mozilla-rust-disable-future-incompat.patch
@@ -1,0 +1,12 @@
+diff -rup a/Cargo.toml b/Cargo.toml
+--- a/Cargo.toml	2023-07-04 15:15:01.089470619 +0200
++++ b/Cargo.toml	2023-07-04 15:24:31.626226962 +0200
+@@ -188,3 +188,8 @@ uniffi_bindgen = "=0.23.0"
+ uniffi_build = "=0.23.0"
+ uniffi_macros = "=0.23.0"
+ weedle2 = "=4.0.0"
++
++# Package code v0.1.4 uses code "that will be rejected by a future version of Rust"
++# Shut up such messages for now to make the build succeed
++[future-incompat-report]
++frequency = "never"


### PR DESCRIPTION
Package code v0.1.4 uses code "that will be rejected by a future version of Rust". Shut up such messages for now to make the build succeed.